### PR TITLE
badge fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Build](https://github.com/quadbiolab/Pando/workflows/build/badge.svg)
+![Build](https://github.com/quadbiolab/Pando/workflows/build/badge.svg?branch=main)
 
 # Pando <img src="man/figures/logo.png" align="right" width="180"/>
 


### PR DESCRIPTION
Currently the status badge displays failing on the main branch, even though last git action run for main was successful. This i s because the devel branch is failing and has been run after the last main branch test.

This can be misleading, so I suggest changing it so it only looks at the main branch instead as written in the badge [docs](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge#using-the-branch-parameter).