### PR TITLE
Update grn.R

### DIFF
--- a/R/grn.R
+++ b/R/grn.R
@@ -261,8 +261,9 @@ fit_grn_models.SeuratPlus <- function(
     peak_data <- peak_data[, peaks_use, drop=FALSE]
 
     log_message('Preparing model input', verbose=verbose)
-    tfs_use <- colnames(motif2tf)
-    motif2tf <- motif2tf[, tfs_use, drop=FALSE]
+    tfs_use <- names(motif2tf)
+    tfs_use <- na.omit(tfs_use)
+    motif2tf <- motif2tf[tfs_use, drop=FALSE]
 
     log_message('Fitting models for ', length(features), ' target genes' , verbose=verbose)
     # Loop through features and fit models/run CV for each


### PR DESCRIPTION
The NetworkTFs() function does not return a data frame or matrix with transcription factor names as column names. As a result, when the program tries to find transcription factors to use - tf_use <- colnames(motif2tf) - R returns an error of incorrect dimensions shortly after saying it's fitting a model. This is during the early part of the infer_grn step. 

Instead, the NetworkTFs() function returns a named numeric, with names being the actual transcription factors. Therefore, my proposed edit is to change the line "tf_use <- colnames(motif2tf)" to "tf_use <- names(motif2tf) %>% na.omit()" and follow it with "motif2tf <- motif2tf[tf_use, drop = FALSE]."