### PR TITLE
Bug fixes for concurrent errors from special characters in inferGRN formulas

### DIFF
--- a/R/grn.R
+++ b/R/grn.R
@@ -335,6 +335,7 @@ fit_grn_models.GRNData <- function(
             }
             peak_name <- str_replace_all(p, '-', '_')
             tf_name <- str_replace_all(peak_tfs, '-', '_')
+            tf_name <- paste0("`", tf_name, "`")
             formula_str <- paste(
                 paste(peak_name, interaction_term, tf_name, sep=' '), collapse = ' + ')
             return(list(tfs=peak_tfs, frml=formula_str))
@@ -347,10 +348,10 @@ fit_grn_models.GRNData <- function(
 
         
         target <- str_replace_all(g, '-', '_')
+        target <- paste0("`", target, "`")
         model_frml <- as.formula(
             paste0(target, ' ~ ', paste0(map(frml_string, function(x) x$`frml`),  collapse=' + '))
         )
-    
         
         # Get expression data
         nfeats <- sum(map_dbl(frml_string, function(x) length(x$`tfs`)))
@@ -363,7 +364,7 @@ fit_grn_models.GRNData <- function(
                                       
         log_message('Fitting model with ', nfeats, ' variables for ', g, verbose=verbose==2)
         result <- try(fit_model(
-            model_frml,
+            `model_frml`,
             data = model_mat,
             method = method,
             ...
@@ -449,8 +450,8 @@ format_coefs <- function(coefs, term=':', adjust_method='fdr'){
         select(-region_, -tf_) %>%
         mutate(
             region = str_replace_all(region, '_', '-'),
-            tf = str_replace_all(tf, '_', '-'),
-            target = str_replace_all(target, '_', '-')
+            tf = str_replace_all(tf, '_', '-') %>% str_replace_all(target, '`', ''),
+            target = str_replace_all(target, '_', '-') %>% str_replace_all(target, '`', '')
         ) %>%
         select(tf, target, region, term, everything())
     return(coefs_use)

--- a/R/grn.R
+++ b/R/grn.R
@@ -334,9 +334,7 @@ fit_grn_models.GRNData <- function(
                 return()
             }
             peak_name <- str_replace_all(p, '-', '_')
-            tf_name <- str_replace_all(peak_tfs, '-', '_')
-            #some gene names contain special characters
-            tf_name <- str_replace_all(tf_name, "\\\\([:\\(\\)])", "\\1") 
+            tf_name <- str_replace_all(peak_tfs, '-', '_') %>% str_replace_all("[\\(\\)]", "\\\\\\0")  #some gene names contain special characters
             formula_str <- paste(
                 paste(peak_name, interaction_term, tf_name, sep=' '), collapse = ' + ')
             return(list(tfs=peak_tfs, frml=formula_str))
@@ -347,8 +345,7 @@ fit_grn_models.GRNData <- function(
             return()
         }
 
-        target <- str_replace_all(g, '-', '_')
-        target <- str_replace_all(target, "\\\\([:\\(\\)])", "\\1")
+        target <- str_replace_all(g, '-', '_') %>% str_replace_all("[\\(\\)]", "\\\\\\0") 
         model_frml <- as.formula(
             paste0(target, ' ~ ', paste0(map(frml_string, function(x) x$frml),  collapse=' + '))
         )
@@ -360,8 +357,7 @@ fit_grn_models.GRNData <- function(
         model_mat <- as.data.frame(cbind(gene_x, peak_x))
         if (scale) model_mat <- as.data.frame(scale(as.matrix(model_mat)))
                                       
-        colnames(model_mat) <- str_replace_all(colnames(model_mat), '-', '_')
-        colnames(model_mat) <- str_replace_all(colnames(model_mat), "\\\\([:\\(\\)])", "\\1")                        
+        colnames(model_mat) <- str_replace_all(colnames(model_mat), '-', '_') %>% str_replace_all("[\\(\\)]", "\\\\\\0")                      
 
         log_message('Fitting model with ', nfeats, ' variables for ', g, verbose=verbose==2)
         result <- try(fit_model(
@@ -451,8 +447,8 @@ format_coefs <- function(coefs, term=':', adjust_method='fdr'){
         select(-region_, -tf_) %>%
         mutate(
             region = str_replace_all(region, '_', '-'),
-            tf = str_replace_all(tf, "([:\\(\\)])", "\\\\\\1") %>% str_replace_all('_', '-'),
-            target = str_replace_all(target, "([:\\(\\)])", "\\\\\\1") %>% str_replace_all('_', '-')
+            tf = str_replace_all(tf, '_', '-'),
+            target = str_replace_all(target, '_', '-')
         ) %>%
         select(tf, target, region, term, everything())
     return(coefs_use)

--- a/R/grn.R
+++ b/R/grn.R
@@ -334,7 +334,9 @@ fit_grn_models.GRNData <- function(
                 return()
             }
             peak_name <- str_replace_all(p, '-', '_')
-            tf_name <- str_replace_all(peak_tfs, '-', '_') %>% str_replace_all("[\\(\\)]", "\\\\\\0")   #some gene names contain special characters
+            tf_name <- str_replace_all(peak_tfs, '-', '_') %>%
+                       str_replace_all("[\\(\\)]", "") %>% 
+                       str_replace_all(":", "")  #some gene names contain special characters, remove
             formula_str <- paste(
                 paste(peak_name, interaction_term, tf_name, sep=' '), collapse = ' + ')
             return(list(tfs=peak_tfs, frml=formula_str))
@@ -346,13 +348,9 @@ fit_grn_models.GRNData <- function(
         }
 
         
-        target <- str_replace_all(g, '-', '_') %>% str_replace_all("[\\(\\)]", "\\\\\\0")  
+        target <- str_replace_all(g, '-', '_') %>% str_replace_all("[\\(\\)]", "") %>% 
+                       str_replace_all(":", "")  #some gene names contain special characters, remove
 
-        frml_string <- map(frml_string, function(x) {
-            # Escape special characters like parentheses
-            x$frml <- str_replace_all(x$frml, '[\\(\\)]', '\\\\\\0')
-            return(x)
-            })
         model_frml <- as.formula(
             paste0(target, ' ~ ', paste0(map(frml_string, function(x) x$frml),  collapse=' + '))
         )
@@ -366,7 +364,8 @@ fit_grn_models.GRNData <- function(
         if (scale) model_mat <- as.data.frame(scale(as.matrix(model_mat)))
                                       
         colnames(model_mat) <- str_replace_all(colnames(model_mat), '-', '_') %>% 
-                                      str_replace_all("[\\(\\)]", "\\\\\\0")                        
+                                        str_replace_all("[\\(\\)]", "") %>% 
+                                        str_replace_all(":", "")  #some gene names contain special characters, remove                       
         log_message('Fitting model with ', nfeats, ' variables for ', g, verbose=verbose==2)
         result <- try(fit_model(
             model_frml,
@@ -455,10 +454,8 @@ format_coefs <- function(coefs, term=':', adjust_method='fdr'){
         select(-region_, -tf_) %>%
         mutate(
             region = str_replace_all(region, '_', '-'),
-            tf = str_replace_all(tf, '_', '-') %>%
-                   str_replace_all("\\\\([\\(\\)])", "\\1"),
-            target = str_replace_all(target, '_', '-') %>%
-                   str_replace_all("\\\\([\\(\\)])", "\\1")
+            tf = str_replace_all(tf, '_', '-'),
+            target = str_replace_all(target, '_', '-')
         ) %>%
         select(tf, target, region, term, everything())
     return(coefs_use)

--- a/R/grn.R
+++ b/R/grn.R
@@ -334,7 +334,7 @@ fit_grn_models.GRNData <- function(
                 return()
             }
             peak_name <- str_replace_all(p, '-', '_')
-            tf_name <- str_replace_all(peak_tfs, '-', '_') %>% str_replace_all("[\\(\\)]", "\\\\\\\\0")   #some gene names contain special characters
+            tf_name <- str_replace_all(peak_tfs, '-', '_') %>% str_replace_all("[\\(\\)]", "\\\\\\0")   #some gene names contain special characters
             formula_str <- paste(
                 paste(peak_name, interaction_term, tf_name, sep=' '), collapse = ' + ')
             return(list(tfs=peak_tfs, frml=formula_str))
@@ -345,7 +345,7 @@ fit_grn_models.GRNData <- function(
             return()
         }
 
-        target <- str_replace_all(g, '-', '_') %>% str_replace_all("[\\(\\)]", "\\\\\\\\0")  
+        target <- str_replace_all(g, '-', '_') %>% str_replace_all("[\\(\\)]", "\\\\\\0")  
         model_frml <- as.formula(
             paste0(target, ' ~ ', paste0(map(frml_string, function(x) x$frml),  collapse=' + '))
         )
@@ -358,7 +358,7 @@ fit_grn_models.GRNData <- function(
         if (scale) model_mat <- as.data.frame(scale(as.matrix(model_mat)))
                                       
         colnames(model_mat) <- str_replace_all(colnames(model_mat), '-', '_') %>% 
-                                      str_replace_all("[\\(\\)]", "\\\\\\\\0")                        
+                                      str_replace_all("[\\(\\)]", "\\\\\\0")                        
         log_message('Fitting model with ', nfeats, ' variables for ', g, verbose=verbose==2)
         result <- try(fit_model(
             model_frml,
@@ -447,8 +447,10 @@ format_coefs <- function(coefs, term=':', adjust_method='fdr'){
         select(-region_, -tf_) %>%
         mutate(
             region = str_replace_all(region, '_', '-'),
-            tf = str_replace_all(tf, '_', '-'),
-            target = str_replace_all(target, '_', '-')
+            tf = str_replace_all(tf, '_', '-') %>%
+                   str_replace_all("\\\\([\\(\\)])", "\\1"),
+            target = str_replace_all(target, '_', '-') %>%
+                   str_replace_all("\\\\([\\(\\)])", "\\1")
         ) %>%
         select(tf, target, region, term, everything())
     return(coefs_use)

--- a/R/grn.R
+++ b/R/grn.R
@@ -334,7 +334,7 @@ fit_grn_models.GRNData <- function(
                 return()
             }
             peak_name <- str_replace_all(p, '-', '_')
-            tf_name <- str_replace_all(peak_tfs, '-', '_') %>% str_replace_all("[\\(\\)]", "\\\\\\0")  #some gene names contain special characters
+            tf_name <- str_replace_all(peak_tfs, '-', '_') %>% str_replace_all("[\\(\\)]", "\\\\\\\\0")   #some gene names contain special characters
             formula_str <- paste(
                 paste(peak_name, interaction_term, tf_name, sep=' '), collapse = ' + ')
             return(list(tfs=peak_tfs, frml=formula_str))
@@ -345,11 +345,11 @@ fit_grn_models.GRNData <- function(
             return()
         }
 
-        target <- str_replace_all(g, '-', '_') %>% str_replace_all("[\\(\\)]", "\\\\\\0") 
+        target <- str_replace_all(g, '-', '_') %>% str_replace_all("[\\(\\)]", "\\\\\\\\0")  
         model_frml <- as.formula(
             paste0(target, ' ~ ', paste0(map(frml_string, function(x) x$frml),  collapse=' + '))
         )
-
+        
         # Get expression data
         nfeats <- sum(map_dbl(frml_string, function(x) length(x$tfs)))
         gene_tfs <- purrr::reduce(map(frml_string, function(x) x$tfs), union)
@@ -357,8 +357,8 @@ fit_grn_models.GRNData <- function(
         model_mat <- as.data.frame(cbind(gene_x, peak_x))
         if (scale) model_mat <- as.data.frame(scale(as.matrix(model_mat)))
                                       
-        colnames(model_mat) <- str_replace_all(colnames(model_mat), '-', '_') %>% str_replace_all("[\\(\\)]", "\\\\\\0")                      
-
+        colnames(model_mat) <- str_replace_all(colnames(model_mat), '-', '_') %>% 
+                                      str_replace_all("[\\(\\)]", "\\\\\\\\0")                        
         log_message('Fitting model with ', nfeats, ' variables for ', g, verbose=verbose==2)
         result <- try(fit_model(
             model_frml,

--- a/R/grn.R
+++ b/R/grn.R
@@ -453,6 +453,7 @@ format_coefs <- function(coefs, term=':', adjust_method='fdr'){
         ) %>%
         select(-region_, -tf_) %>%
         mutate(
+            term = str_replace_all(term, '_', '-') %>% str_replace_all('`', ''),
             region = str_replace_all(region, '_', '-') %>% str_replace_all('`', ''),
             tf = str_replace_all(tf, '_', '-') %>% str_replace_all('`', ''),
             target = str_replace_all(target, '_', '-') %>% str_replace_all('`', '')

--- a/R/grn.R
+++ b/R/grn.R
@@ -335,6 +335,8 @@ fit_grn_models.GRNData <- function(
             }
             peak_name <- str_replace_all(p, '-', '_')
             tf_name <- str_replace_all(peak_tfs, '-', '_')
+            #some gene names contain special characters
+            tf_name <- str_replace_all(tf_name, "([:\\(\\)])", "\\\\\\1") 
             formula_str <- paste(
                 paste(peak_name, interaction_term, tf_name, sep=' '), collapse = ' + ')
             return(list(tfs=peak_tfs, frml=formula_str))
@@ -346,6 +348,7 @@ fit_grn_models.GRNData <- function(
         }
 
         target <- str_replace_all(g, '-', '_')
+        target <- str_replace_all(target, "([:\\(\\)])", "\\\\\\1")
         model_frml <- as.formula(
             paste0(target, ' ~ ', paste0(map(frml_string, function(x) x$frml),  collapse=' + '))
         )
@@ -356,7 +359,9 @@ fit_grn_models.GRNData <- function(
         gene_x <- gene_data[gene_groups, union(g, gene_tfs), drop=FALSE]
         model_mat <- as.data.frame(cbind(gene_x, peak_x))
         if (scale) model_mat <- as.data.frame(scale(as.matrix(model_mat)))
+                                      
         colnames(model_mat) <- str_replace_all(colnames(model_mat), '-', '_')
+        colnames(model_mat) <- str_replace_all(colnames(model_mat), "([:\\(\\)])", "\\\\\\1")                        
 
         log_message('Fitting model with ', nfeats, ' variables for ', g, verbose=verbose==2)
         result <- try(fit_model(
@@ -446,14 +451,12 @@ format_coefs <- function(coefs, term=':', adjust_method='fdr'){
         select(-region_, -tf_) %>%
         mutate(
             region = str_replace_all(region, '_', '-'),
-            tf = str_replace_all(tf, '_', '-'),
-            target = str_replace_all(target, '_', '-')
+            tf = str_replace_all(tf, "\\\\([:\\(\\)])", "\\1") %>% str_replace_all('_', '-'),
+            target = str_replace_all(target, "\\\\([:\\(\\)])", "\\1") %>% str_replace_all('_', '-')
         ) %>%
         select(tf, target, region, term, everything())
     return(coefs_use)
 }
-
-
 
 #' Find TF modules in regulatory network
 #'

--- a/R/grn.R
+++ b/R/grn.R
@@ -201,7 +201,7 @@ fit_grn_models.GRNData <- function(
             group_name = aggregate_rna_col,
             verbose = FALSE
         )
-        gene_groups <- object@meta.data[[aggregate_rna_col]]
+        gene_groups <- object@data@meta.data[[aggregate_rna_col]]
     }
 
     if (is.null(aggregate_peaks_col)){

--- a/R/grn.R
+++ b/R/grn.R
@@ -345,10 +345,18 @@ fit_grn_models.GRNData <- function(
             return()
         }
 
+        
         target <- str_replace_all(g, '-', '_') %>% str_replace_all("[\\(\\)]", "\\\\\\0")  
+
+        frml_string <- map(frml_string, function(x) {
+            # Escape special characters like parentheses
+            x$frml <- str_replace_all(x$frml, '[\\(\\)]', '\\\\\\0')
+            return(x)
+            })
         model_frml <- as.formula(
             paste0(target, ' ~ ', paste0(map(frml_string, function(x) x$frml),  collapse=' + '))
         )
+    
         
         # Get expression data
         nfeats <- sum(map_dbl(frml_string, function(x) length(x$tfs)))

--- a/R/grn.R
+++ b/R/grn.R
@@ -336,7 +336,7 @@ fit_grn_models.GRNData <- function(
             peak_name <- str_replace_all(p, '-', '_')
             tf_name <- str_replace_all(peak_tfs, '-', '_')
             #some gene names contain special characters
-            tf_name <- str_replace_all(tf_name, "([:\\(\\)])", "\\\\\\1") 
+            tf_name <- str_replace_all(tf_name, "\\\\([:\\(\\)])", "\\1") 
             formula_str <- paste(
                 paste(peak_name, interaction_term, tf_name, sep=' '), collapse = ' + ')
             return(list(tfs=peak_tfs, frml=formula_str))
@@ -348,7 +348,7 @@ fit_grn_models.GRNData <- function(
         }
 
         target <- str_replace_all(g, '-', '_')
-        target <- str_replace_all(target, "([:\\(\\)])", "\\\\\\1")
+        target <- str_replace_all(target, "\\\\([:\\(\\)])", "\\1")
         model_frml <- as.formula(
             paste0(target, ' ~ ', paste0(map(frml_string, function(x) x$frml),  collapse=' + '))
         )
@@ -361,7 +361,7 @@ fit_grn_models.GRNData <- function(
         if (scale) model_mat <- as.data.frame(scale(as.matrix(model_mat)))
                                       
         colnames(model_mat) <- str_replace_all(colnames(model_mat), '-', '_')
-        colnames(model_mat) <- str_replace_all(colnames(model_mat), "([:\\(\\)])", "\\\\\\1")                        
+        colnames(model_mat) <- str_replace_all(colnames(model_mat), "\\\\([:\\(\\)])", "\\1")                        
 
         log_message('Fitting model with ', nfeats, ' variables for ', g, verbose=verbose==2)
         result <- try(fit_model(
@@ -451,12 +451,13 @@ format_coefs <- function(coefs, term=':', adjust_method='fdr'){
         select(-region_, -tf_) %>%
         mutate(
             region = str_replace_all(region, '_', '-'),
-            tf = str_replace_all(tf, "\\\\([:\\(\\)])", "\\1") %>% str_replace_all('_', '-'),
-            target = str_replace_all(target, "\\\\([:\\(\\)])", "\\1") %>% str_replace_all('_', '-')
+            tf = str_replace_all(tf, "([:\\(\\)])", "\\\\\\1") %>% str_replace_all('_', '-'),
+            target = str_replace_all(target, "([:\\(\\)])", "\\\\\\1") %>% str_replace_all('_', '-')
         ) %>%
         select(tf, target, region, term, everything())
     return(coefs_use)
 }
+                   
 
 #' Find TF modules in regulatory network
 #'

--- a/R/grn.R
+++ b/R/grn.R
@@ -336,6 +336,7 @@ fit_grn_models.GRNData <- function(
                 return()
             }
             peak_name <- str_replace_all(p, '-', '_')
+            peak_name <- paste0("`", peak_name, "`")
             tf_name <- str_replace_all(peak_tfs, '-', '_')
             tf_name <- paste0("`", tf_name, "`")
             formula_str <- paste(
@@ -452,7 +453,7 @@ format_coefs <- function(coefs, term=':', adjust_method='fdr'){
         ) %>%
         select(-region_, -tf_) %>%
         mutate(
-            region = str_replace_all(region, '_', '-'),
+            region = str_replace_all(region, '_', '-') %>% str_replace_all('`', ''),
             tf = str_replace_all(tf, '_', '-') %>% str_replace_all('`', ''),
             target = str_replace_all(target, '_', '-') %>% str_replace_all('`', '')
         ) %>%

--- a/R/grn.R
+++ b/R/grn.R
@@ -336,7 +336,9 @@ fit_grn_models.GRNData <- function(
             peak_name <- str_replace_all(p, '-', '_')
             tf_name <- str_replace_all(peak_tfs, '-', '_') %>%
                        str_replace_all("[\\(\\)]", "") %>% 
-                       str_replace_all(":", "")  #some gene names contain special characters, remove
+                       str_replace_all(":", "") %>%
+                        str_replace_all("^([0-9])", "X\\1")
+                         #some gene names contain special characters, remove
             formula_str <- paste(
                 paste(peak_name, interaction_term, tf_name, sep=' '), collapse = ' + ')
             return(list(tfs=peak_tfs, frml=formula_str))
@@ -348,8 +350,10 @@ fit_grn_models.GRNData <- function(
         }
 
         
-        target <- str_replace_all(g, '-', '_') %>% str_replace_all("[\\(\\)]", "") %>% 
-                       str_replace_all(":", "")  #some gene names contain special characters, remove
+        target <- str_replace_all(g, '-', '_') %>% 
+                        str_replace_all("[\\(\\)]", "") %>% 
+                           str_replace_all(":", "") %>%
+                                str_replace_all("^([0-9])", "X\\1")  #some gene names contain special characters, remove
 
         model_frml <- as.formula(
             paste0(target, ' ~ ', paste0(map(frml_string, function(x) x$frml),  collapse=' + '))
@@ -365,7 +369,8 @@ fit_grn_models.GRNData <- function(
                                       
         colnames(model_mat) <- str_replace_all(colnames(model_mat), '-', '_') %>% 
                                         str_replace_all("[\\(\\)]", "") %>% 
-                                        str_replace_all(":", "")  #some gene names contain special characters, remove                       
+                                        str_replace_all(":", "") %>%
+                                        str_replace_all("^([0-9])", "X\\1") #some gene names contain special characters, remove                       
         log_message('Fitting model with ', nfeats, ' variables for ', g, verbose=verbose==2)
         result <- try(fit_model(
             model_frml,

--- a/R/grn.R
+++ b/R/grn.R
@@ -453,8 +453,8 @@ format_coefs <- function(coefs, term=':', adjust_method='fdr'){
         select(-region_, -tf_) %>%
         mutate(
             region = str_replace_all(region, '_', '-'),
-            tf = str_replace_all(tf, '_', '-') %>% str_replace_all(target, '`', ''),
-            target = str_replace_all(target, '_', '-') %>% str_replace_all(target, '`', '')
+            tf = str_replace_all(tf, '_', '-') %>% str_replace_all('`', ''),
+            target = str_replace_all(target, '_', '-') %>% str_replace_all('`', '')
         ) %>%
         select(tf, target, region, term, everything())
     return(coefs_use)


### PR DESCRIPTION
There were several issues noted coming from chromosome names and gene names containing special characters. For example, in the dm6 assembly, the NCBI chromosome notations are 3R, 3L, etc, throwing the formula input. Gene name problems included those starting with integers, containing parentheses, colons, and the gene "if" which was parsed as an if/then statement - to say the least. 
I have updated the code to account for that by automatically backticking regions and gene names and then removing those backticks in the code. This should also remove the necessity for str_replace_all to convert "-" to "_", though I have not removed these lines. This should be a universal fix, but please let me know if it is not. 